### PR TITLE
Added dependency for versions of Node.js before 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"network-byte-order": "0.x"
 	},
 	"engines": {
-		"node": "0.x"
+		"node": "0.x < 0.9.2"
 	},
 	"licenses": [
 		{


### PR DESCRIPTION
I tested this module with `0.9.2` of Node.js and the `ondata` does not match the Socket wanting to use `socket.on('data', .....` so it doesn't work. I already re-wrote it as a new module (`proxysocket`) but wanted to let others know this module won't work for newer versions of Node.js currently.

Thanks,
Kris
