### PR TITLE
Add 'cork' and 'uncork' pass-through methods

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -64,6 +64,14 @@ Socks5ClientSocket.prototype.address = function() {
 	return this.socket.address();
 };
 
+Socks5ClientSocket.prototype.cork = function() {
+	return this.socket.cork();
+};
+
+Socks5ClientSocket.prototype.uncork = function() {
+	return this.socket.uncork();
+};
+
 Socks5ClientSocket.prototype.pause = function() {
 	return this.socket.pause();
 };


### PR DESCRIPTION
In order to work with recent versions of Node, two more methods on the underlying socket need to be used, so two more pass-through methods needed.