### PR TITLE
resolve authentication errors

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -159,7 +159,7 @@ function authenticateWithSocks(client, cb) {
 
 				if (2 !== data.length) {
 					error = 'Unexpected number of bytes received.';
-				} else if (0x05 !== data[0]) {
+				} else if (0x01 !== data[0]) {
 					error = 'Unexpected SOCKS version number: ' + data[0] + '.';
 				} else if (0x00 !== data[1]) {
 					error = 'Username and password authentication failure: ' + data[1] + '.';
@@ -172,10 +172,15 @@ function authenticateWithSocks(client, cb) {
 				}
 			});
 
-			request = [];
-			parseString(client.socksUsername, request);
-			parseString(client.socksPassword, request);
-			client.write(Buffer.from(request));
+			var userLen = Buffer.byteLength(client.socksUsername);
+			var passLen = Buffer.byteLength(client.socksPassword);
+			var req = new Buffer(3 + userLen + passLen);
+			req[0] = 0x01;
+			req[1] = userLen;
+			req.write(client.socksUsername, 2, userLen);
+			req[2 + userLen] = passLen;
+			req.write(client.socksPassword, 3 + userLen, passLen);
+			client.socket.write(Buffer.from(req));
 
 		// No authentication to negotiation.
 		} else {


### PR DESCRIPTION
resolve error authentication errors:
- Error: SOCKS authentication failed. Unexpected number of bytes received.
- Error: SOCKS authentication failed. Unexpected SOCKS version number: 1.
