### PR TITLE
Older nodejs support (at least for V4)

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -145,7 +145,7 @@ function authenticateWithSocks(client, cb) {
 			error = 'Unexpected SOCKS version number: ' + data[0] + '.';
 		} else if (0xFF === data[1]) {
 			error = 'No acceptable authentication methods were offered.';
-		} else if (!authMethods.includes(data[1])) {
+		} else if (authMethods.indexOf(data[1]) === -1) {
 			error = 'Unexpected SOCKS authentication method: ' + data[1] + '.';
 		}
 
@@ -177,7 +177,7 @@ function authenticateWithSocks(client, cb) {
 			request = [0x01];
 			parseString(client.socksUsername, request);
 			parseString(client.socksPassword, request);
-			client.write(Buffer.from(request));
+			client.write(new Buffer(request));
 
 		// No authentication to negotiate.
 		} else {
@@ -260,7 +260,7 @@ function connectSocksToHost(client, host, port, cb) {
 	// Add a placeholder for the port bytes.
 	request.length += 2;
 
-	buffer = Buffer.from(request);
+	buffer = new Buffer(request);
 	buffer.writeUInt16BE(port, buffer.length - 2, true);
 
 	client.write(buffer);

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -267,7 +267,7 @@ function connectSocksToHost(client, host, port, cb) {
 }
 
 function parseString(string, request) {
-	var buffer = Buffer.from(string), i, l = buffer.length;
+	var buffer = new Buffer(string), i, l = buffer.length;
 
 	// Declare the length of the following string.
 	request.push(l);


### PR DESCRIPTION
Works on the default Ubuntu 16.04 LTS version of nodejs again. (V4). Unsure if older versions also work, I expect so.