### PR TITLE
Changes required to enable  HTTP keep-alive for an agent using this socket implementation

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -29,9 +29,18 @@ function Socks5ClientSocket(options) {
 			self.socket.destroy();
 		}
 	});
+	self.on('end', self.end)
 }
 
 inherits(Socks5ClientSocket, EventEmitter);
+
+Socks5ClientSocket.prototype.ref = function () {
+	return this.socket.ref();
+};
+
+Socks5ClientSocket.prototype.unref = function () {
+	return this.socket.unref();
+};
 
 Socks5ClientSocket.prototype.setTimeout = function(msecs, callback) {
 	return this.socket.setTimeout(msecs, callback);
@@ -69,7 +78,10 @@ Socks5ClientSocket.prototype.pipe = function(e) {
 };
 
 Socks5ClientSocket.prototype.end = function(data, encoding) {
-	return this.socket.end(data, encoding);
+	let tmp = this.socket.end(data, encoding);
+	// copy writable state from underlying socket
+	this.writable = this.socket.writable;
+	return tmp;
 };
 
 Socks5ClientSocket.prototype.destroy = function(exception) {

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -78,10 +78,11 @@ Socks5ClientSocket.prototype.pipe = function(e) {
 };
 
 Socks5ClientSocket.prototype.end = function(data, encoding) {
-	let tmp = this.socket.end(data, encoding);
-	// copy writable state from underlying socket
-	this.writable = this.socket.writable;
-	return tmp;
+	var ret = this.socket.end(data, encoding);
+
+	this.writable = this.socket.writable; // copy writable state from underlying socket
+	
+	return ret;
 };
 
 Socks5ClientSocket.prototype.destroy = function(exception) {


### PR DESCRIPTION
I added wrappers for ref() and unref() functions of the underlying socket which are required to allow the keepAlive option of an http(s) agent. Furthermore, I implemented setting the writable state properly after an end event has occurred.
Together with allowing direct instantiation of the socks5-http(s)-client agents, these changes enable using HTTP keep-alive when using a SOCKS5 proxy. 