### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -268,7 +268,7 @@ function connectSocksToHost(client, host, port, cb) {
 	request.length += 2;
 
 	buffer = new Buffer(request);
-	buffer.writeUInt16BE(port, buffer.length - 2, true);
+	buffer.writeUInt16BE(port, buffer.length - 2);
 
 	client.write(buffer);
 }


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should. Sadly there is not test to verify this currently.

Refs: https://github.com/nodejs/node/pull/18395