### PR TITLE
Fix: Use agentOptions instead of root options

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -15,10 +15,10 @@ function Socks5ClientSocket(options) {
 	EventEmitter.call(self);
 
 	self.socket = new net.Socket();
-	self.socksHost = options.socksHost || 'localhost';
-	self.socksPort = options.socksPort || 1080;
-	self.socksUsername = options.socksUsername;
-	self.socksPassword = options.socksPassword;
+	self.socksHost = options.agentOptions.socksHost || 'localhost';
+	self.socksPort = options.agentOptions.socksPort || 1080;
+	self.socksUsername = options.agentOptions.socksUsername;
+	self.socksPassword = options.agentOptions.socksPassword;
 
 	self.socket.on('error', function(err) {
 		self.emit('error', err);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "socks5-client",
 	"description": "SOCKS v5 client socket implementation.",
-	"version": "1.2.8",
+	"version": "1.2.9",
 	"main": "index.js",
 	"homepage": "https://github.com/mattcg/socks5-client",
 	"implements": ["CommonJS/Modules/1.0"],


### PR DESCRIPTION
The options that are used get stuck with the first options provided, at least when using `agentOptions` with Request. I don't know if this will work if one uses the package directly.